### PR TITLE
Update package to be compatible with postcss 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 [ci-img]:  https://travis-ci.org/GarthDB/postcss-inherit.svg
 [ci]:      https://travis-ci.org/GarthDB/postcss-inherit
 
-A port of the [Rework Inherit](https://github.com/reworkcss/rework-inherit) plugin to PostCSS.
+A wrapper around the [Rework Inherit](https://github.com/reworkcss/rework-inherit) plugin for PostCSS.
 
 You can find all the documentation you might need over on the other plugin's [README](https://github.com/reworkcss/rework-inherit/blob/master/README.md).

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ var parse = require('postcss/lib/parse');
 module.exports = postcss.plugin('postcss-inherit', function (opts) {
     opts = opts || {};
 
-  // Work with options here
+    // Work with options here
 
-    return function (css) {
+    return function (css, result) {
         var inputCSS = css.toString();
         var outputCSS = rework(inputCSS).use(inherit(opts)).toString();
-        return parse(outputCSS);
+        result.root = parse(outputCSS);
     };
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "postcss": "^4.1.9",
+    "postcss": "^5.0.10",
     "rework": "1.0.1",
     "rework-inherit": "https://github.com/reworkcss/rework-inherit/tarball/master"
   },
@@ -25,7 +25,7 @@
     "gulp": "^3.8.11",
     "gulp-eslint": "^0.12.0",
     "gulp-mocha": "^2.0.1",
-    "postcss-import": "^6.0.0"
+    "postcss-import": "^7.0.0"
   },
   "scripts": {
     "test": "gulp"


### PR DESCRIPTION
review? @GarthDB 

This PR adds support for postcss ^5.0.0, which removed and replaced the [return root api](https://github.com/postcss/postcss/issues/231).

This would be a breaking change for this package, removing support for postcss <= 4.1
